### PR TITLE
Fix mapping conflicts

### DIFF
--- a/plugin/chatgpt.vim
+++ b/plugin/chatgpt.vim
@@ -11,14 +11,14 @@ function! GPT()
     echo "\n" . output
     if confirm("Write output at cursor position? (Y/n)", "&Yes\n&No") == 1
       call feedkeys("i")
-      call feedkeys(output)
+      call feedkeys(output, "n")
     endif
   else
     let output = system("chatgpt '" . prompt . "'")
     echo "\n" . output
     if confirm("Write output at cursor position? (Y/n)", "&Yes\n&No") == 1
       call feedkeys("i")
-      call feedkeys(output)
+      call feedkeys(output, "n")
     endif
   endif
 endfunction
@@ -31,7 +31,7 @@ function! GPTRun()
     echo "\n" . output
     if confirm("Write output at cursor position? (Y/n)", "&Yes\n&No") == 1
       call feedkeys("i")
-      call feedkeys(output)
+      call feedkeys(output, "n")
     endif
   endif
 endfunction
@@ -44,7 +44,7 @@ function! GPTFile()
     echo "\n" . output
     if confirm("Write output at cursor position? (Y/n)", "&Yes\n&No") == 1
       call feedkeys("i")
-      call feedkeys(output)
+      call feedkeys(output, "n")
     endif
   endif
 endfunction


### PR DESCRIPTION
Adds the 'n' flag to not remap keys. This fixes a potential conflict with different mappings and led to linebreaks being omitted in my case.

Fixes https://github.com/0xStabby/chatgpt-vim/issues/4